### PR TITLE
Fix zen priority mode vibration logic.

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -2735,7 +2735,7 @@ public class NotificationManagerService extends SystemService {
 
         boolean canBeep = readyForBeepOrBuzz && canInterrupt;
         boolean canBuzz = readyForBeepOrBuzz &&
-            (canInterrupt || mZenModeHelper.allowVibrationForNotifications());
+            (canInterrupt || (aboveThreshold && mZenModeHelper.allowVibrationForNotifications()));
         boolean hasValidSound = false;
 
         if (canBeep || canBuzz) {


### PR DESCRIPTION
Even if zen priority mode is active and vibration is allowed, we still
want to keep notifications with score below the threshold silent.

Change-Id: I0a60bbd787e7f98f721129902054ab37fb9f58a7